### PR TITLE
#5 OxyPlot 왼쪽 클릭 이벤트 시 다른 컨트롤 동기화 테스트

### DIFF
--- a/DynamicCreateTest/MainWindowViewModel.cs
+++ b/DynamicCreateTest/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using GraphCtrlLib;
 using OxyPlot.Axes;
 using System;
@@ -126,8 +127,37 @@ namespace DynamicCreateTest
             //Timer 초기화
             timer = new DispatcherTimer();
             timer.Interval = TimeSpan.FromMilliseconds(5);
-            timer.Tick += CallBackTimer; 
+            timer.Tick += CallBackTimer;
 
+            #region Messenger
+
+            var Messageee = WeakReferenceMessenger.Default;
+            Messageee.Register<GraphCtrlLib.Message.SharedMessge>(this, OnMessageReceived);
+
+            #endregion
+
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="obj"></param> 객체 전송자
+        /// <param name="message"></param> 메세지
+        private void OnMessageReceived(object obj, GraphCtrlLib.Message.SharedMessge message)
+        {
+            double DataX = message.DataX;
+            double DataY = message.DataY;
+
+            double sDataX = message.sDataX;
+            double sDataY = message.sDataY;
+
+            object e = message.e;
+
+            int Index = message.DataIndex;
+
+            foreach (GraphViewModel _graph in _viewModels)
+            {
+                _graph.SyncTracker(DataX, DataY, sDataX, sDataY, e, Index);
+            }
         }
 
         public double xData = new double();

--- a/GraphCtrlLib/CustomTrackerManipulator/StayOpenTrackerManipulator.cs
+++ b/GraphCtrlLib/CustomTrackerManipulator/StayOpenTrackerManipulator.cs
@@ -1,4 +1,7 @@
-﻿using OxyPlot;
+﻿using CommunityToolkit.Mvvm.Messaging;
+using GraphCtrlLib.Message;
+using OxyPlot;
+using OxyPlot.Series;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +19,62 @@ namespace GraphCtrlLib.CustomTrackerManipulator
         }
         public override void Completed(OxyMouseEventArgs e)
         {
-            // Do nothing
+            // Message 전달
+            if(this.PlotView != null && this.PlotView.ActualModel != null)
+            {
+                Series currentSeries = this.PlotView.ActualModel.GetSeriesFromPoint(e.Position, FiresDistance);
+                if (currentSeries != null)
+                {
+                    var hitTestResult = currentSeries.HitTest(new HitTestArguments(e.Position, FiresDistance));
+
+                    if (hitTestResult != null && hitTestResult.Item != null)
+                    {
+                        // 해당 데이터 포인트
+                        var dataPoint = (DataPoint)hitTestResult.Item;
+
+                        WeakReferenceMessenger.Default.Send(new SharedMessge 
+                        { 
+                            DataX = dataPoint.X, 
+                            DataY = dataPoint.Y,
+                            sDataX = e.Position.X, 
+                            sDataY = e.Position.Y,
+                            DataIndex = Convert.ToInt32(hitTestResult.Index),
+                            e = e
+                        });
+                    }
+                }
+            }
+        }
+        public void ShowTracker( Series series, DataPoint point, ScreenPoint sPoint, object obj, int Index)
+        {         
+            //DataPoint를 가지고 현재 객체의 ScreenPoint를 얻는다.
+            var xAxis = this.PlotView.ActualModel.Axes.FirstOrDefault(a => a.Position == OxyPlot.Axes.AxisPosition.Bottom);
+
+            if(xAxis != null) 
+            {
+                //Index를 가지고 Series를 가져오는 방법
+                //LineSeries ls = series as LineSeries;
+                //var DataPoints = ls.Points[Index];
+
+                double screenX = xAxis.Transform(point.X);
+
+                //Screen Point가 자신의 PlotArea 범위 내에 있는 지 확인
+                if (!this.PlotView.ActualModel.PlotArea.Contains(screenX, this.PlotView.ActualModel.PlotArea.Top))
+                {
+                    return;
+                }
+
+                var nearestPoint = series.GetNearestPoint(new ScreenPoint(screenX, 0), false);
+
+                if (nearestPoint != null)
+                {
+                    nearestPoint.PlotModel = this.PlotView.ActualModel;
+                    this.PlotView.ShowTracker(nearestPoint);
+                    this.PlotView.ActualModel.RaiseTrackerChanged(nearestPoint);
+
+                    //PlotView.ShowTracker(nearestPoint);
+                }
+            }
         }
     }
 }

--- a/GraphCtrlLib/Message/SharedMessge.cs
+++ b/GraphCtrlLib/Message/SharedMessge.cs
@@ -1,0 +1,19 @@
+﻿using OxyPlot;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GraphCtrlLib.Message
+{
+    public class SharedMessge
+    {
+        public double DataX { get; set; }
+        public double DataY { get; set; }
+        public double sDataX { get; set; }
+        public double sDataY { get; set; }
+        public int DataIndex { get; set; }
+        public object? e { get; set; }
+    }
+}

--- a/GraphCtrlLib/UserControl_Graph.xaml
+++ b/GraphCtrlLib/UserControl_Graph.xaml
@@ -39,6 +39,10 @@
                 <i:EventTrigger EventName="Drop">
                     <i:InvokeCommandAction Command="{Binding PlotDrop}" PassEventArgsToCommand="True" />
                 </i:EventTrigger>
+
+                <i:EventTrigger EventName="Loaded">
+                    <i:InvokeCommandAction Command="{Binding PlotLoadedCommand}" />
+                </i:EventTrigger>
             </i:Interaction.Triggers>
         </oxy:PlotView>
     </Grid>


### PR DESCRIPTION
OxyPlot 왼쪽 클릭 이벤트 시 다른 컨트롤 동기화 테스트

1. 마우스 왼쪽 클릭 이벤트 추가
   - 기존 Tracker 기능을 유지하면서 추가 기능을 할 수 있도록 연구 필요
   
2. Tracker Manipulator를 상속 받아 Complete함수를 Override 하여 유지하도록 구현
   - Plot Control에 BindMouseDown() 호출하면서 AddMouseManipulator()로 CustomerManipulator를 지정할 수 있음

3. WeakReferenceManager 연구
   - WeakReferenceManager를 이용하여 다른 ViewModel에 Message를 전달 할 수 있는 부분을 구현
   - 현재까지는 message형식으로 1:1로 주고 받을 수 있는 것으로 알고 있음.

4. Graph Draw
   - 선택된 Graph의 Screen Point를 이용하여 DataX를 얻음
   - DataX를 메세지로 공유하고, 각 그래프 객체 자신의 DataX에 해당하는 Screen Point을 얻음.
   - 그 위치에 Tracker를 보이도록 구현함.
   - ScreenPoint가 현재 자신의 PlotArea를 벗어났을 경우에 대한 예외처리 필요

5. Graph Data Transform
   - 현재는 LineSeries에 대해서만 연구 진행
   - Touch된 ScreenPoint로 DataPoint를 얻어오는 방법
   - Touch된 ScreenPoint로 DataPoint의 Index를 얻어 오는 방법
   - Index로 Series Data에서 DataPoint를 얻어오는 방법
   - DataPoint로 ScreenPoint를 얻어오는 방법

6. Manipulator
   - Mainipulator 객체 정보를 Delegate 함수에서 생성하고 저장함.
   - 하지만 한번 마우스 터치를 해야만  Delegate가 호출되어 Manipulator 객체가 생성됨
   - 이로 인해, 한번도 터치 하지 않은 Graph의 경우 Manupultor객체가 생성되지 않아 Tracker를 그릴 수 없음.
   - Graph의 로드 완료 이벤트에서 가상 터치를 한 것으로 Delegate를 호출하는 방법을 연구 중...

https://github.com/PLAIF-dev/sw_oxy_plot_wpf_examples_dotnet7/assets/117803230/737ba742-0585-4189-a6d3-279fceef4f7c

